### PR TITLE
Parse html page & extract data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ build-iPhoneSimulator/
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 .DS_Store
+
+# ignore byebug history
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'nokogiri', '~> 1.12', '>= 1.12.3'
+gem 'byebug', '~> 11.1', '>= 11.1.3'
+gem 'rspec', '~> 3.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (11.1.3)
+    diff-lcs (1.4.4)
+    nokogiri (1.12.3-x86_64-linux)
+      racc (~> 1.4)
+    racc (1.5.2)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  byebug (~> 11.1, >= 11.1.3)
+  nokogiri (~> 1.12, >= 1.12.3)
+  rspec (~> 3.10)
+
+BUNDLED WITH
+   2.2.18

--- a/lib/google_parser.rb
+++ b/lib/google_parser.rb
@@ -1,0 +1,53 @@
+require 'nokogiri'
+require 'byebug'
+require 'json'
+
+class GoogleParser
+  def initialize; end
+
+  def call
+    page = File.open('./files/van-gogh-paintings.html')
+    html = Nokogiri::HTML(page)
+    parsed_page = html.css('div.EDblX.DAVP1')
+    data = parsed_page.css('div.MiPcId.klitem-tr.mlo-c a').map do |painting|
+            extracted_data(painting)
+          end
+
+    return JSON.pretty_generate({ artworks: data })
+  end
+
+  private
+
+  def extracted_data(painting)
+    {
+      name: get_name(painting),
+      extensions: [get_date(painting)],
+      link: get_link(painting),
+      image: get_image(painting)
+    }
+  end
+
+  def get_link(painting)
+    "https://www.google.com#{painting.attributes["href"]&.value}"
+  end
+
+  def get_image(painting)
+    painting.at_css('g-img img').attributes["data-key"]&.value
+  end
+
+  def get_name(painting)
+    span = painting.css('.kltat span')
+    if span.count > 1
+      span.first.text + span.last.text
+    else
+      span.first.text
+    end
+  end
+
+  def get_date(painting)
+    painting.at_css('.ellip.klmeta')&.text
+  end
+end
+
+
+puts GoogleParser.new.call

--- a/spec/google_parser_spec.rb
+++ b/spec/google_parser_spec.rb
@@ -1,0 +1,15 @@
+require "google_parser"
+require 'json'
+
+describe GoogleParser do
+  let!(:results) { described_class.new.call }
+  let!(:paintings) do
+    JSON.parse(File.read(Dir.pwd + "/spec/paintings.json"))
+  end
+
+  describe ".call" do
+    it "should return the correct array of paintings" do
+      expect(JSON.parse(results)).to eq(paintings)
+    end
+  end
+end

--- a/spec/paintings.json
+++ b/spec/paintings.json
@@ -1,0 +1,412 @@
+{
+  "artworks": [
+    {
+      "name": "The Starry Night",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+Starry+Night&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLFMzC3jC7WUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYhUIyUhVCC5JLCqqVPDLTM8oAQDmNFnDqgAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYILw",
+      "image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQq3gOqqnprlNb3SdEgrKAR_0sWrsu0kO0aNnwE3yRwmA_cf-PvBvdz4eInim3FDmRn7E0"
+    },
+    {
+      "name": "Irises",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Irises+(painting)&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLGMzUvMi7WUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYhX0LMosTi1W0ChIzASqz0vXBADZ_49eqwAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIMg",
+      "image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcStMSw8ChAG6lRdwQ8XcJJZ3iEo49nC7E--Lub1evBfJDFGs8hri_Ci2MwSHiFuFJVcZYg"
+    },
+    {
+      "name": "Sunflowers",
+      "extensions": [
+        null
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=vase+with+12+sunflowers&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArFMUszTjcu1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGIVL0ssTlUozyzJUDA0UiguzUvLyS9PLSoGAIoORr-yAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYINQ",
+      "image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTJa5Y-t9vzkSCGg06vPfh_mBSZj4JyJ3eE98cFeCkFxJCXcTI2qr1jbv3Bi0Pv5jxouU0"
+    },
+    {
+      "name": "Van Gogh self-portrait",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Van+Gogh+self-portrait&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1k_XNzQyTEk2z8nTUspOttIvyywuTcyJTywqQWJmFpdYlecXZRc_YozkFnj5456wVMCkNSevMXpxEaFJSIWLzTWvJLOkUkiKi0cKbrsGgxQXF5zHs4hVLCwxT8E9Pz1DoTg1J023IL-opCgxswQA-CHMG7IAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIOA",
+      "image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRHWjZ8Hzky-N_7nJEqURtuU5VXp-n3gXHBiam5r6O9mbiQ2alvbkGvwty3HF542jXkc2Q"
+    },
+    {
+      "name": "CafÃ© Terrace at Night",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Caf%C3%A9+Terrace+at+Night&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLFMyg2NLbSUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYhVzTkw7vFIhJLWoKDE5VSGxRMEvMz2jBACpuYkQsAAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIOw",
+      "image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTsexOpUYClT-nKVHltjfb4dLw2lfjnHsFhVQyWZopSLSzlLD3yU0Sslh8bFE2yHs0Yj6g"
+    },
+    {
+      "name": "The Potato Eaters",
+      "extensions": [
+        "1885"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+Potato+Eaters&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLFMTCxMKrWUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYhUMyUhVCMgvSSzJV3BNLEktKgYAoS92w6sAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIPg",
+      "image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSeppKTcFgZvcp7fS0eaIxvWobuUK-Cd_fVOSHRAtmZUd_f3RV4VjqjSe4s-Qiy8qZiodk"
+    },
+    {
+      "name": "Cypresses",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Cypresses+(Metropolitan+Museum+of+Art)&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1k_XNzQyqsiON0nTUspOttIvyywuTcyJTywqQWJmFpdYlecXZRc_YozkFnj5456wVMCkNSevMXpxEaFJSIWLzTWvJLOkUkiKi0cKbrsGgxQXF5zHs4hVzbmyoCi1uDi1WEHDN7WkKL8gPyezJDFPwbe0OLU0VyE_TcGxqEQTAGW4AMDCAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIQQ",
+      "image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRz5P3eqBLnN41ltkAigpjp_S_4ZsH0zMS5DbWN_gNYZdk-m9cujQeXT46uENy2aGcEbfw"
+    },
+    {
+      "name": "Wheatfield with Crows",
+      "extensions": [
+        "1890"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Wheatfield+with+Crows&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLFMkw0KirWUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYhUNz0hNLEnLTM1JUSjPLMlQcC7KLy8GAABEZN2vAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIRA",
+      "image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQB2NTmu5Q4emMZIFSx-RxZEOZvTw4Ev6C0Brqq3oedt74H03Acc07NdKEw9coNER7Tti0"
+    },
+    {
+      "name": "The Yellow House",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+Yellow+House&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLFSzAsNCrSUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYhUIyUhViEzNyckvV_DILy1OBQB6cr9GqgAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIRw",
+      "image": null
+    },
+    {
+      "name": "Starry Night Over the RhÃ´ne",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Starry+Night+Over+the+Rh%C3%B4ne&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLHMjE0tLbSUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYpUJLkksKqpU8MtMzyhR8C9LLVIoyUhVCMo4vCUvFQDcOEu1tgAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYISg",
+      "image": null
+    },
+    {
+      "name": "Almond Blossoms",
+      "extensions": [
+        "1890"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Almond+Blossoms&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1k_XNzQyKM8uSa7SUspOttIvyywuTcyJTywqQWJmFpdYlecXZRc_YozkFnj5456wVMCkNSevMXpxEaFJSIWLzTWvJLOkUkiKi0cKbrsGgxQXF5zHs4iV3zEnNz8vRcEpJ7-4OD-3GADVlODTqwAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYITQ",
+      "image": null
+    },
+    {
+      "name": "At Eternity's Gate",
+      "extensions": [
+        "1890"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=At+Eternity's+Gate&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLHSTXLT8rSUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYhVyLFFwLUktygMqVS9WcE8sSQUAV5EbKKwAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIUA",
+      "image": null
+    },
+    {
+      "name": "The Red Vineyard",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+Red+Vineyard&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLGMko3Ly7SUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYhUIyUhVCEpNUQjLzEutTCxKAQB21PAuqgAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIUw",
+      "image": null
+    },
+    {
+      "name": "The Night CafÃ©",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+Night+Caf%C3%A9&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLHSjcrzqrSUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYuUPyUhV8MtMzyhRcE5MO7wSAFvdlcSpAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIVg",
+      "image": null
+    },
+    {
+      "name": "Self-portrait without beard",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Self-portrait+without+beard&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1U_XNzRMKjfMMMkqK9RSyk620i_LLC5NzIlPLCpBYmYWl1iV5xdlFz9ijOQWePnjnrBUwKQ1J68xenERoUlIhYvNNa8ks6RSSIqLRwpuvwaDFBcXnMeziFU6ODUnTbcgv6ikKDGzRKE8syQjv7REISk1sSgFAFJ86rS5AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIWQ",
+      "image": null
+    },
+    {
+      "name": "Self-Portrait with Bandaged Ear",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Self-Portrait+with+Bandaged+Ear&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArFMk0pSqiy1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGKVD07NSdMNyC8qKUrMLFEozyzJUHBKzEtJTE9NUXBNLAIAZyU60LoAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIXA",
+      "image": null
+    },
+    {
+      "name": "Peasant Woman Against a Background of Wheat",
+      "extensions": [
+        "1890"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Peasant+Woman+Against+a+Background+of+Wheat&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLEszA3zjLSUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYtUOSE0sTswrUQjPz03MU3BMT8zMKy5RSFRwSkzOTi_KL81LUchPUwjPSE0sAQCYqFS_xQAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIXw",
+      "image": null
+    },
+    {
+      "name": "Field with plowing farmers",
+      "extensions": [
+        null
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Field+with+plowing+farmers&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1U_XNzRMNsqNN4zPNtBSyk620i_LLC5NzIlPLCpBYmYWl1iV5xdlFz9ijOQWePnjnrBUwKQ1J68xenERoUlIhYvNNa8ks6RSSIqLRwpuvwaDFBcXnMeziFXKLTM1J0WhPLMkQ6EgJ788My9dIS2xKDe1qBgAUNR_8bgAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIYg",
+      "image": null
+    },
+    {
+      "name": "Wheat Field with Cypresses",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Wheat+Field+with+Cypresses&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArFMSnJMTeK1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGKVCs9ITSxRcMtMzUlRKM8syVBwriwoSi0uTi0GAI3LmqO1AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIZQ",
+      "image": null
+    },
+    {
+      "name": "Olive Trees",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Olive+Trees+(Van+Gogh+series)&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArHSs1KSc0u0lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGKV9c_JLEtVCClKTS1W0AhLzFNwz0_PUChOLcpMLdYEALQL__24AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIaA",
+      "image": null
+    },
+    {
+      "name": "Bedroom in Arles",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Bedroom+in+Arles&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArEsi02MCtO0lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGIVcEpNKcrPz1XIzFNwLMpJLQYAlW4c46sAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIaw",
+      "image": null
+    },
+    {
+      "name": "Portrait of PÃ¨re Tanguy",
+      "extensions": [
+        "1887"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Portrait+of+P%C3%A8re+Tanguy&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArHSs1KyDMq0lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGKVCMgvKilKzCxRyE9TCDi8oihVISQxL720EgDV4AIFswAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIbg",
+      "image": null
+    },
+    {
+      "name": "Portrait of the Postman Joseph Roulin",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Portrait+of+the+Postman+Joseph+Roulin&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArHMjLOMCiy1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGJVDcgvKilKzCxRyE9TKMlIVQjILy7JTcxT8MovTi3IUAjKL83JzAMAeUvTJcAAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIcQ",
+      "image": null
+    },
+    {
+      "name": "The Church at Auvers",
+      "extensions": [
+        "1890"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+Church+at+Auvers&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLHM0tIq8rSUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYhUJyUhVcM4oLUrOUEgsUXAsLUstKgYAUiv71K4AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIdA",
+      "image": null
+    },
+    {
+      "name": "The garden of the Asylum",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+garden+of+the+Asylum&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1U_XNzRMKi_MLTdIMtdSyk620i_LLC5NzIlPLCpBYmYWl1iV5xdlFz9ijOQWePnjnrBUwKQ1J68xenERoUlIhYvNNa8ks6RSSIqLRwpuvwaDFBcXnMeziFUiJCNVIT2xKCU1TyE_TaEEyHMsrswpzQUAx6xvf7YAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIdw",
+      "image": null
+    },
+    {
+      "name": "Le Moulin de Blute-Fin",
+      "extensions": [
+        "1886"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Le+Moulin+de+Blute-Fin&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArEy0quMqyq1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGIV80lV8M0vzcnMU0hJVXDKKS1J1XXLzAMA3k1m7rEAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIeg",
+      "image": null
+    },
+    {
+      "name": "Enclosed Field with Ploughman",
+      "extensions": [
+        null
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Enclosed+Field+with+Ploughman&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1U_XNzRMzi5Ly6oyN9RSyk620i_LLC5NzIlPLCpBYmYWl1iV5xdlFz9ijOQWePnjnrBUwKQ1J68xenERoUlIhYvNNa8ks6RSSIqLRwpuvwaDFBcXnMeziFXWNS85J784NUXBLTM1J0WhPLMkQyEgJ780PSM3MQ8AYXdpr7sAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIfQ",
+      "image": null
+    },
+    {
+      "name": "Van Gogh's Chair",
+      "extensions": [
+        null
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Van+Gogh's+Chair&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1k_XNzQyKiw2MY3XUspOttIvyywuTcyJTywqQWJmFpdYlecXZRc_YozkFnj5456wVMCkNSevMXpxEaFJSIWLzTWvJLOkUkiKi0cKbrsGgxQXF5zHs4hVICwxT8E9Pz1DvVjBOSMxswgAR_AXXqwAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIgAE",
+      "image": null
+    },
+    {
+      "name": "Autumn Landscape with Four Trees",
+      "extensions": [
+        "1885"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Autumn+Landscape+with+Four+Trees&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1U_XNzRMzi5JLzYsytZSyk620i_LLC5NzIlPLCpBYmYWl1iV5xdlFz9ijOQWePnjnrBUwKQ1J68xenERoUlIhYvNNa8ks6RSSIqLRwpuvwaDFBcXnMeziFXBsbSkNDdPwScxL6U4ObEgVaE8syRDwS2_tEghpCg1tRgAaB6sPb4AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIgwE",
+      "image": null
+    },
+    {
+      "name": "Fishing Boats on the Beach at Saintes-Maries",
+      "extensions": [
+        null
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Fishing+Boats+on+the+Beach+at+Saintes-Maries&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1k_XNzQyzEvPtbDQUspOttIvyywuTcyJTywqQWJmFpdYlecXZRc_YozkFnj5456wVMCkNSevMXpxEaFJSIWLzTWvJLOkUkiKi0cKbrsGgxQXF5zHs4hVxy2zOCMzL13BKT-xpFghP0-hJCNVwSk1MTlDIbFEITgxM68ktVjXN7EoM7UYALOPXxHIAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIhgE",
+      "image": null
+    },
+    {
+      "name": "Skull of a Skeleton with Burning Cigarette",
+      "extensions": [
+        null
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Skull+of+a+Skeleton+with+Burning+Cigarette&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArGyjMzTcnO1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGLVCs4uzclRyE9TSFQIzk7NSS3Jz1MozyzJUHAqLcrLzEtXcM5MTyxKLSlJBQCWDRItxQAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIiQE",
+      "image": null
+    },
+    {
+      "name": "Self-Portrait with Grey Felt Hat",
+      "extensions": [
+        "1887"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Self-Portrait+with+Grey+Felt+Hat&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArFMi3OK4w21lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGJVCE7NSdMNyC8qKUrMLFEozyzJUHAvSq1UcEvNKVHwSCwBAPX4-l27AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIjAE",
+      "image": null
+    },
+    {
+      "name": "White House at Night",
+      "extensions": [
+        "1890"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=White+House+at+Night&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArHMyk0MzLK0lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGIVCc_ILElV8MgvLU5VSCxR8MtMzygBADSN2EmvAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIjwE",
+      "image": null
+    },
+    {
+      "name": "Woman Sewing",
+      "extensions": [
+        "1885"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Woman+Sewing&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1U_XNzRMKi_MLS8yztZSyk620i_LLC5NzIlPLCpBYmYWl1iV5xdlFz9ijOQWePnjnrBUwKQ1J68xenERoUlIhYvNNa8ks6RSSIqLRwpuvwaDFBcXnMeziJUnPD83MU8hOLU8My8dALy4YoeqAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIkgE",
+      "image": null
+    },
+    {
+      "name": "Arles: View from the Wheat Fields",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Arles:+View+from+the+Wheat+Fields&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArFSUpJL0tO1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGJVdCzKSS22UgjLTC1XSCvKz1UoyUhVCM9ITSxRcMtMzUkpBgApcnsvvAAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIlQE",
+      "image": null
+    },
+    {
+      "name": "The siesta (after Millet)",
+      "extensions": [
+        null
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+siesta+(after+Millet)&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi0U_XNzS0rDA3LKiq1FLKTrbSL8ssLk3MiU8sKkFiZhaXWJXnF2UXP2KM5BZ4-eOesFTApDUnrzF6cRGhSUiFi801rySzpFJIiotHCm69BoMUFxecx7OIVTIkI1WhODO1uCRRQSMxrSS1SME3MycntUQTAMJ_kSS2AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYImAE",
+      "image": null
+    },
+    {
+      "name": "Sorrow",
+      "extensions": [
+        "1882"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Sorrow+(Van+Gogh)&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArFK4tNMUgq1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGIVDM4vKsovV9AIS8xTcM9Pz9AEAIQvoy-sAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYImwE",
+      "image": null
+    },
+    {
+      "name": "Sunset at Montmajour",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Sunset+at+Montmajour&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArHKq0pM4nO1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGIVCS7NK04tUUgsUfDNzyvJTczKLy0CADGrIhqvAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIngE",
+      "image": null
+    },
+    {
+      "name": "Avenue of Poplars in Autumn",
+      "extensions": [
+        "1884"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Avenue+of+Poplars+in+Autumn&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArHSS8oKciy1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGKVdixLzStNVchPUwjIL8hJLCpWyMxTcCwtKc3NAwBpI31WtgAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIoQE",
+      "image": null
+    },
+    {
+      "name": "The Pink Peach Tree",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+Pink+Peach+Tree&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArGSDdPLzdK0lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGIVDslIVQjIzMtWCEhNTM5QCClKTQUAVErhIq4AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIpAE",
+      "image": null
+    },
+    {
+      "name": "Road with Cypress and Star",
+      "extensions": [
+        "1890"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Road+with+Cypress+and+Star&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArGyjMziK0q0lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGKVCspPTFEozyzJUHCuLChKLS5WSMxLUQguSSwCAJK6Tty1AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIpwE",
+      "image": null
+    },
+    {
+      "name": "Bulb Fields",
+      "extensions": [
+        "1883"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Bulb+Fields&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArGScpNNzfO0lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGLldirNSVJwy0zNSSkGAPUySIemAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIqgE",
+      "image": null
+    },
+    {
+      "name": "Gauguin's Chair",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Gauguin's+Chair&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1k_XNzQyqDA3MzTXUspOttIvyywuTcyJTywqQWJmFpdYlecXZRc_YozkFnj5456wVMCkNSevMXpxEaFJSIWLzTWvJLOkUkiKi0cKbrsGgxQXF5zHs4iV3z2xNL00M0-9WME5IzGzCACyL3FRqwAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIrQE",
+      "image": null
+    },
+    {
+      "name": "View of Arles, Flowering Orchards",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=View+of+Arles,+Flowering+Orchards&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiBLHSU5KycrWUspOt9Msyi0sTc-ITi0qQmJnFJVbl-UXZxY8YI7kFXv64JywVMGnNyWuMXlxEaBJS4WJzzSvJLKkUkuLikYLbrcEgxcUF5_EsYlUMy0wtV8hPU3Asykkt1lFwy8kvTy3KzEtX8C9KzkgsSikGAGz2iO27AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIsAE",
+      "image": null
+    },
+    {
+      "name": "Poppy Flowers",
+      "extensions": [
+        "1887"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Poppy+Flowers&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArGSi5Kzy6u0lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGLlDcgvKKhUcMvJL08tKgYAbFdAT6gAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIswE",
+      "image": null
+    },
+    {
+      "name": "View of Arles with Irises in the Foreground",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=View+of+Arles+with+Irises+in+the+Foreground&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1k_XNzQyNM6LLy_UUspOttIvyywuTcyJTywqQWJmFpdYlecXZRc_YozkFnj5456wVMCkNSevMXpxEaFJSIWLzTWvJLOkUkiKi0cKbrsGgxQXF5zHs4hVOywztVwhP03BsSgntVihPLMkQ8GzKLMYyM7MUyjJSFVwyy9KTS_KL81LAQA7Oy6-xwAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYItgE",
+      "image": null
+    },
+    {
+      "name": "The Road Menders",
+      "extensions": [
+        "1889"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=The+Road+Menders&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArFMjKqyK4q1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGIVCMlIVQjKT0xR8E3NS0ktKgYAJyVE0asAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIuQE",
+      "image": null
+    },
+    {
+      "name": "La MousmÃ©",
+      "extensions": [
+        "1888"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=La+Mousm%C3%A9&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArFMk6uMiuK1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGLl8klU8M0vLc49vBIAbt_trKUAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIvAE",
+      "image": null
+    },
+    {
+      "name": "Avenue of Poplars at Sunset",
+      "extensions": [
+        "1884"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Avenue+of+Poplars+at+Sunset&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArHSS8pTqtK1lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGKVdixLzStNVchPUwjIL8hJLCpWSCxRCC7NK04tAQDmxWgztgAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIvwE",
+      "image": null
+    },
+    {
+      "name": "Prisoners Exercising",
+      "extensions": [
+        "1890"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Prisoners+Exercising&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLiArGSyjLKDZO0lLKTrfTLMotLE3PiE4tKkJiZxSVW5flF2cWPGCO5BV7-uCcsFTBpzclrjF5cRGgSUuFic80rySypFJLi4pGCW67BIMXFBefxLGIVCSjKLM7PSy0qVnCtSC1KzizOzEsHADgDirKvAAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIwgE",
+      "image": null
+    },
+    {
+      "name": "Portrait of Adeline Ravoux",
+      "extensions": [
+        "1890"
+      ],
+      "link": "https://www.google.com/search?gl=us&hl=en&q=Portrait+of+Adeline+Ravoux&stick=H4sIAAAAAAAAAONgFuLQz9U3MI_PNVLi1k_XNzQyyjYzTq7SUspOttIvyywuTcyJTywqQWJmFpdYlecXZRc_YozkFnj5456wVMCkNSevMXpxEaFJSIWLzTWvJLOkUkiKi0cKbrsGgxQXF5zHs4hVKiC_qKQoMbNEIT9NwTElNSczL1UhKLEsv7QCAOSAHzG2AAAA&npsic=0&sa=X&ved=0ahUKEwiL2_Hon4_hAhXNZt4KHTOAACwQ-BYIxQE",
+      "image": null
+    }
+  ]
+}


### PR DESCRIPTION
### How to run
`ruby lib/google_parser.rb` Should print out the results
`rspec .` Should run test cases

### Important notes

- I couldn't test with 2 different carousels because the current google implementation is different than the HTML page you gave me
- The image URL in the expected array is not the same one as the HTML page. After a little research, I found out the HTML page uses the cached URLs that Google uses not the ones in the expected array. 