### PR TITLE
Sonia: Extract Van Gogh paintings solution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'nokogiri', '~> 1.13'
+gem 'rspec', '~> 3.11'
+gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.6.2)
+    json (2.7.6)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
+    racc (1.8.1)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.6)
+
+PLATFORMS
+  arm64-darwin-24
+
+DEPENDENCIES
+  json
+  nokogiri (~> 1.13)
+  rspec (~> 3.11)
+
+BUNDLED WITH
+   2.4.3

--- a/spec/van_gogh_extractor_spec.rb
+++ b/spec/van_gogh_extractor_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../van_gogh_extractor'
+
+RSpec.describe VanGoghExtractor do
+  let(:extractor) { VanGoghExtractor.new('files/van-gogh-paintings.html') }
+  let(:result) { extractor.extract_artworks }
+  
+  it 'returns hash with artworks array' do
+    expect(result).to have_key('artworks')
+    expect(result['artworks']).to be_an(Array)
+  end
+  
+  it 'extracts multiple artworks' do
+    expect(result['artworks'].length).to be > 10
+  end
+  
+  it 'finds The Starry Night' do
+    starry_night = result['artworks'].find { |art| art['name'].include?('Starry Night') }
+    expect(starry_night).not_to be_nil
+    expect(starry_night['extensions']).to include('1889')
+  end
+  
+  it 'extracts required fields for each artwork' do
+    result['artworks'].each do |artwork|
+      expect(artwork).to have_key('name')
+      expect(artwork).to have_key('extensions')
+      expect(artwork).to have_key('link')
+      expect(artwork).to have_key('image')
+      
+      expect(artwork['name']).to be_a(String)
+      expect(artwork['extensions']).to be_an(Array)
+    end
+  end
+  
+  it 'creates valid Google search links' do
+    links = result['artworks'].map { |art| art['link'] }.compact
+    expect(links.length).to be > 10
+    
+    links.each do |link|
+      expect(link).to start_with('https://www.google.com')
+    end
+  end
+end

--- a/van_gogh_extractor.rb
+++ b/van_gogh_extractor.rb
@@ -1,0 +1,127 @@
+require 'nokogiri'
+require 'json'
+
+class VanGoghExtractor
+  def initialize(html_file_path)
+    @html_content = File.read(html_file_path)
+    @doc = Nokogiri::HTML(@html_content)
+  end
+
+  def extract_artworks
+    artworks = []
+    carousel_items = @doc.css('.iELo6')
+
+    if carousel_items.empty?
+      carousel_items = @doc.css('div').select do |div|
+        div.css('img').any? && div.css('a').any?
+      end
+    end
+    
+    carousel_items.each do |item|
+      artwork = extract_painting_data(item)
+      artworks << artwork if artwork
+    end
+    
+    unique_artworks = artworks.uniq { |art| art['name'].downcase }
+
+    { "artworks" => unique_artworks }
+  end
+
+  private
+
+  def extract_painting_data(item)
+    name = extract_name(item)
+    return nil if name.nil? || name.strip.empty?
+
+    {
+      "name" => name,
+      "extensions" => extract_years(item),
+      "link" => extract_link(item),
+      "image" => extract_image(item)
+    }
+  end
+
+  def extract_name(item)
+    name_element = item.css('.pgNMRc').first
+    if name_element
+      name = name_element.text.strip
+      return clean_name(name) unless name.empty?
+    end
+    
+    img = item.css('img').first
+    if img && img['alt']
+      return clean_name(img['alt'])
+    end
+    
+    nil
+  end
+
+  def clean_name(raw_name)
+    cleaned = raw_name.gsub(/^(Van Gogh:\s*|Vincent van Gogh:\s*)/i, '')
+    cleaned = cleaned.gsub(/\s*\(\d{4}\).*$/, '')
+    cleaned.strip
+  end
+
+  def extract_years(item)
+    years = []
+    year_element = item.css('.cxzHyb').first
+    if year_element
+      year_text = year_element.text.strip
+      years << year_text if year_text.match?(/^\d{4}$/)
+    end
+    
+    if years.empty?
+      text_content = item.text
+      year_matches = text_content.scan(/\b(18\d{2}|19\d{2})\b/)
+      years = year_matches.flatten.uniq
+    end
+    
+    years
+  end
+
+  def extract_link(item)
+    link_element = item.css('a').first
+    return nil unless link_element
+    
+    href = link_element['href']
+    return nil unless href
+    
+    if href.start_with?('/search') || href.start_with?('/')
+      "https://www.google.com#{href}"
+    else
+      href
+    end
+  end
+
+  def extract_image(item)
+    img = item.css('img').first
+    return nil unless img
+
+    image_url = img['data-src'] || img['src']
+    return nil unless image_url
+    return nil if image_url.include?('data:image/gif;base64,R0lGODlhAQABAI')
+
+    if image_url.start_with?('//')
+      "https:#{image_url}"
+    elsif image_url.start_with?('/')
+      "https://www.google.com#{image_url}"
+    else
+      image_url
+    end
+  end
+
+  def self.extract_from_file(file_path)
+    extractor = new(file_path)
+    extractor.extract_artworks
+  end
+end
+
+if __FILE__ == $0
+  if ARGV.empty?
+    puts "Usage: ruby van_gogh_extractor.rb <html_file>"
+    exit 1
+  end
+  
+  result = VanGoghExtractor.extract_from_file(ARGV[0])
+  puts JSON.pretty_generate(result)
+end


### PR DESCRIPTION
## Overview
This PR adds the Van Gogh Extractor solution, including setup, execution, and testing.

### Summary
- Implemented `van_gogh_extractor.rb` to parse Google’s carousel HTML and extract Van Gogh artworks.
- Extracts 40+ paintings with: `name`, `extensions`, `link`, `image`
- Added RSpec tests (`spec/van_gogh_extractor_spec.rb`) covering core functionality.

###  Local Testing
- Run extractor

```bash
ruby van_gogh_extractor.rb files/van-gogh-paintings.html
```

Expected JSON output includes paintings like Café Terrace at Night (1888), The Potato Eaters (1885), and Sunflowers.

- Run tests

```bash
bundle exec rspec
```

Tests validate that the extractor:

1. Returns an artworks array
2. Extracts multiple artworks
3. Ensures required fields (name, extensions, link, image) exist
4. Produces valid Google search links