### PR TITLE
feat(extractor): implement Ruby parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ build-iPhoneSimulator/
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 .DS_Store
+.vscode/

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format documentation
+--color

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "nokogiri", "~> 1.16"
+
+group :development, :test do
+  gem "rspec", "~> 3.13"
+  gem "debug"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,109 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    diff-lcs (1.6.2)
+    erb (6.0.4)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-musl)
+      racc (~> 1.4)
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
+    racc (1.8.1)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    stringio (3.2.0)
+    tsort (0.2.0)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  debug
+  nokogiri (~> 1.16)
+  rspec (~> 3.13)
+
+CHECKSUMS
+  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
+  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
+  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
+  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
+  nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
+  nokogiri (1.19.3-x86_64-darwin) sha256=77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d
+  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
+  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
+  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+
+BUNDLED WITH
+  4.0.12

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Extract Van Gogh Paintings Code Challenge
 
 Goal is to extract a list of Van Gogh paintings from the attached Google search results page.
@@ -23,6 +24,6 @@ Parse directly the HTML result page ([html file]) in this repository. No extra H
 
 Add also to your array the painting thumbnails present in the result page file (not the ones where extra requests are needed). 
 
-Test against 2 other similar result pages to make sure it works against different layouts. (Pages that contain the same kind of carrousel. Don't necessarily have to be paintings.)
+Test against 2 other similar result pages to make sure it works against different layouts. (Pages that contain the same kind of carrousel. Don't necessarily have to be paintings.)
 
 The suggested time for this challenge is 4 hours. But, you can take your time and work more on it if you want.

--- a/RUN.md
+++ b/RUN.md
@@ -1,0 +1,68 @@
+# Run Guide
+
+This file contains setup, run, lint, and test commands for this script.
+
+## Prerequisites
+
+- Ruby
+- Bundler
+
+## Setup
+
+Install dependencies:
+
+```bash
+bundle install
+```
+
+## Run Extractor
+
+Run extractor on the provided fixture:
+
+```bash
+bin/extract files/van-gogh-paintings.html
+```
+
+Save output:
+
+```bash
+bin/extract files/van-gogh-paintings.html > /tmp/artworks.json
+```
+
+Programmatic use:
+
+```ruby
+require_relative "lib/extractor"
+
+result = Extractor.call("files/van-gogh-paintings.html")
+puts result.first
+```
+
+## Run Tests
+
+Run all specs:
+
+```bash
+bundle exec rspec
+```
+
+Run one spec file:
+
+```bash
+bundle exec rspec spec/extractor_spec.rb
+```
+
+## Lint
+
+Run syntax lint checks:
+
+```bash
+bundle exec bin/lint
+```
+
+`bin/lint` runs `ruby -wc` across `lib/`, `spec/`, and `bin/`.
+
+## Local Quality Checks
+
+1. `bundle exec bin/lint`
+2. `bundle exec rspec`

--- a/bin/extract
+++ b/bin/extract
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "extractor"
+require "json"
+
+if ARGV.empty?
+  warn "Usage: bin/extract <path-to-html>"
+  exit 64
+end
+
+puts JSON.pretty_generate("artworks" => Extractor.call(ARGV[0]))

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "rbconfig"
+
+files = Dir["lib/**/*.rb", "spec/**/*.rb", "bin/*"]
+files.select! { |path| File.file?(path) }
+files.sort!
+
+failed = []
+
+files.each do |path|
+  ok = system(RbConfig.ruby, "-wc", path)
+  failed << path unless ok
+end
+
+if failed.any?
+  warn "\nLint failed for #{failed.size} file(s):"
+  failed.each { |path| warn "- #{path}" }
+  exit 1
+end
+
+puts "\nLint passed for #{files.size} file(s)."

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -1,0 +1,38 @@
+require "nokogiri"
+
+require_relative "extractor/thumbnail_index"
+require_relative "extractor/carousel"
+require_relative "extractor/item"
+
+module Extractor
+  # Public facade. Returns an Array<Hash> of carousel items.
+  #
+  # Why this shape:
+  # - Callers only need one method (`Extractor.call`) and don't manage objects.
+  # - Internally we still use small classes for focused responsibilities.
+  # 
+  #   Extractor.call("files/van-gogh-paintings.html")
+  #   # => [{ "name" => "The Starry Night", "extensions" => ["1889"], ... }, ...]
+  # Accepts either a file path string or raw HTML string.
+  def self.call(html_or_path)
+    # Support both CLI/file use and test/raw-html use with one entrypoint.
+    html = if File.file?(html_or_path.to_s)
+      File.read(html_or_path)
+    else
+      html_or_path
+    end
+
+    # Parse once into DOM, then build the thumbnail map once.
+    # This avoids repeatedly scanning <script> nodes for every tile.
+    document = Nokogiri::HTML(html)
+    thumbnails = ThumbnailIndex.build(document)
+
+    # Keep parse pipeline explicit:
+    # 1) find best carousel tiles
+    # 2) parse each tile
+    # 3) drop malformed/nil rows
+    Carousel.tiles(document).map do |tile|
+      Item.parse(tile, thumbnails: thumbnails)
+    end.compact
+  end
+end

--- a/lib/extractor/carousel.rb
+++ b/lib/extractor/carousel.rb
@@ -1,0 +1,105 @@
+require_relative "item"
+
+module Extractor
+  # Locates the knowledge-graph carousel on a desktop Google SERP. Google
+  # rotates CSS class names regularly, so we identify the carousel by its
+  # structural signature: a container holding a run of sibling tiles, where
+  # every tile has exactly one anchor to /search?... with a `stick=` param
+  # (the knowledge-graph entity stick).
+  class Carousel
+    # Heuristic floor to filter tiny, usually-noisy stick-link groups.
+    MIN_TILES = 3
+
+    # Class-level convenience API keeps caller usage functional:
+    #   Carousel.tiles(document)
+    # while still allowing private helpers and local state internally.
+    def self.tiles(document)
+      new(document).tiles
+    end
+
+    # Stores the document as instance state so private methods can access
+    # it without threading it through every method call.
+    def initialize(document)
+      @document = document
+    end
+
+    def tiles
+      groups = candidate_groups
+      return [] if groups.empty?
+
+      # Multiple stick-link groups can exist on one page. We prefer the group
+      # that most strongly looks like media tiles, then fall back to DOM order
+      # for deterministic behavior on ties.
+      # deterministic tie-breaking removes "heisenbugs" where output can vary by Ruby/hash iteration behavior.
+      scored = groups.map { |g| [group_score(g), g] }
+      best_score = scored.map(&:first).max
+      best_groups = scored.select { |score, _| score == best_score }.map(&:last)
+      best_groups.min_by { |g| document_position(g.first) } || []
+    end
+
+    private
+
+    # Build candidate groups by:
+    #   1. Finding every `/search?…&stick=…` anchor.
+    #   2. Walking each anchor up to its *tile root* — the highest ancestor
+    #      that still contains exactly one stick anchor.
+    #   3. Grouping tile roots by their common parent. A group with
+    #      MIN_TILES+ siblings is a carousel candidate.
+    def candidate_groups
+      # Structural fingerprint that avoids volatile CSS class names.
+      anchors = @document.css('a[href*="stick="]').select do |a|
+        href = a["href"].to_s
+        # Relative and absolute google-search links are both accepted.
+        href.start_with?("/search") || href.include?("google.com/search")
+      end
+
+      # Convert each anchor to the smallest "tile root" node that represents
+      # one tile (not a nested sub-node, not the whole carousel container).
+      tile_roots = anchors.map { |a| tile_root_for(a) }.compact.uniq
+
+      # Sibling tile roots under the same parent form one carousel candidate.
+      grouped = tile_roots.group_by(&:parent)
+      grouped.delete(nil)
+
+      # Drop weak candidates early.
+      grouped.values.select { |g| g.size >= MIN_TILES }
+    end
+
+    # Score shape:
+    #   1) tiles with an image element
+    #   2) tiles with a likely name signal
+    #   3) group size
+    #
+    # This keeps us anchored on structural evidence instead of class names.
+    def group_score(group)
+      # Prefer groups that look like media cards.
+      with_image = group.count { |tile| tile.at_css("img") }
+      # Name-like signals provide a second quality axis.
+      with_name = group.count { |tile| tile.at_css('img[alt], a[aria-label], a[title]') }
+      [with_image, with_name, group.size]
+    end
+
+    def document_position(node)
+      return Float::INFINITY unless node
+      # DOM-order fallback is stable and explainable.
+      @document.css("*").index(node) || Float::INFINITY
+    end
+
+    # Walk up from `anchor` while the current node's parent still contains
+    # only one stick anchor. The last such node is the tile root — adding
+    # one more level would absorb sibling tiles.
+    def tile_root_for(anchor)
+      node = anchor
+      loop do
+        parent = node.parent
+        return node unless parent
+
+        # As soon as parent contains multiple stick anchors, walking higher
+        # would merge sibling tiles. Current node is the tile root boundary.
+        stick_count = parent.css('a[href*="stick="]').size
+        return node if stick_count != 1
+        node = parent
+      end
+    end
+  end
+end

--- a/lib/extractor/item.rb
+++ b/lib/extractor/item.rb
@@ -1,0 +1,123 @@
+require "uri"
+
+module Extractor
+  # One carousel tile. We deliberately avoid pinning to volatile Google CSS
+  # class names (`pgNMRc`, `cxzHyb`, ...) and instead navigate by structure:
+  #   - the tile is built around a single <a href="/search?...">
+  #   - the <img> alt attribute carries the canonical name
+  #   - direct text-node descendants under the anchor that are not the name
+  #     are treated as extensions (year, medium, etc.)
+  class Item
+    GOOGLE_BASE = "https://www.google.com".freeze
+
+    # Class-level convenience API for callers.
+    def self.parse(node, thumbnails:)
+      new(node, thumbnails).to_h
+    end
+
+    def initialize(node, thumbnails)
+      @node = node
+      @thumbnails = thumbnails
+      @anchor = node.at_css("a[href]")
+      @img = node.at_css("img")
+    end
+
+    def to_h
+      # Minimum contract: without anchor or name, tile isn't usable.
+      return nil unless @anchor && name
+
+      {
+        "name" => name,
+        "extensions" => extensions,
+        "link" => link,
+        "image" => image,
+      }
+    end
+
+    private
+
+    def name
+      @name ||= begin
+        # Ordered fallback chain:
+        # 1) <img alt> is usually canonical title on Google tiles.
+        # 2) aria-label/title cover accessibility or layout variants.
+        # 3) first text block is a final rescue for unusual markup.
+        candidates = [
+          @img && @img["alt"],
+          @anchor["aria-label"],
+          @anchor["title"],
+          first_text_block,
+        ]
+        candidates.map { |c| c && c.strip }.find { |c| c && !c.empty? }
+      end
+    end
+
+    # Anything under the anchor that isn't the name. We deliberately walk only
+    # *leaf* elements (no element children) so we don't capture container text
+    # that concatenates name + extension (e.g., "The Starry Night1889").
+    # An array is preserved to keep parity with the SerpApi schema even when
+    # Google adds extra chips (e.g., medium, location).
+    def extensions
+      # Leaf-only text prevents container text like "Name1889" from leaking in.
+      leaves = @anchor.css("div, span").reject { |n| n.element_children.any? }
+      texts = leaves.map { |n| n.text.strip }.reject(&:empty?).uniq
+      # Remove duplicated title if it appears as a chip.
+      texts.delete(name)
+      texts.reject! { |t| t.length > 80 } # guard against accidental block grabs
+      return nil if texts.empty?
+      texts
+    end
+
+    def link
+      href = @anchor["href"].to_s
+      return nil if href.empty?
+      # Keep existing absolute URLs unchanged.
+      return href if href.start_with?("http")
+      # Normalize relative Google paths so consumers get absolute links.
+      URI.join(GOOGLE_BASE, href).to_s
+    end
+
+    # Resolution order matters:
+    #   1. ThumbnailIndex lookup by <img id> — Google ships the real base64
+    #      image via inline JS; the <img src> is a 1x1 transparent GIF
+    #      placeholder until that JS runs.
+    #   2. In-file attributes (`data-src`, then `src`) for non-placeholder
+    #      data URIs.
+    #   3. In-file URL thumbnails (`data-src` or `src`) when present.
+    #
+    # Requirement fit: the requirements asks for thumbnails present in the result
+    # page file without extra requests. `data-src=https://...` values qualify
+    # because they are already in the HTML snapshot.
+    def image
+      return nil unless @img
+
+      # Primary path: image id resolved from inline JS mapping.
+      from_index = @img["id"] && @thumbnails[@img["id"]]
+      return from_index if from_index
+
+      data_src = @img["data-src"].to_s
+      src = @img["src"].to_s
+
+      return data_src if data_src.start_with?("data:") && !placeholder?(data_src)
+      # Accept inline non-placeholder data only.
+      return src if src.start_with?("data:") && !placeholder?(src)
+
+      [data_src, src].each do |candidate|
+        return candidate if candidate.start_with?("http://", "https://")
+      end
+
+      nil
+    end
+
+    # 1x1 transparent GIF Google uses as the pre-hydration placeholder.
+    PLACEHOLDER_PREFIX = "data:image/gif;base64,R0lGOD".freeze
+    def placeholder?(src)
+      src.start_with?(PLACEHOLDER_PREFIX)
+    end
+
+    def first_text_block
+      # Fallback used only when stronger name signals are missing.
+      @anchor.xpath(".//text()").map(&:to_s).map(&:strip).find { |t| !t.empty? }
+    end
+  end
+end

--- a/lib/extractor/thumbnail_index.rb
+++ b/lib/extractor/thumbnail_index.rb
@@ -1,0 +1,61 @@
+module Extractor
+  # Google ships inline thumbnails as JS blocks of the shape:
+  #
+  #   (function(){var s='data:image/jpeg;base64,...';
+  #    var ii=['_id1','_id2'];var r='';_setImagesSrc(ii,s,r);})();
+  #
+  # The visible <img> tag's `src` is just a 1x1 GIF placeholder; the real
+  # thumbnail is injected at runtime against the image id(s) listed in `ii`.
+  # We replicate that mapping at parse time so no JS execution is required.
+  class ThumbnailIndex
+    # Greedy on the data URI body, anchored on the trailing `_setImagesSrc(ii,s,r)`
+    # to avoid mis-pairing s/ii from adjacent script blocks.
+    BLOCK_REGEX = /
+      var\s+s\s*=\s*'(?<data>data:image\/[^']+)'\s*;\s*
+      var\s+ii\s*=\s*\[(?<ids>[^\]]*)\]\s*;\s*
+      var\s+r\s*=\s*'[^']*'\s*;\s*
+      _setImagesSrc\(ii,\s*s,\s*r\)
+    /xm.freeze
+
+    ID_REGEX = /'([^']+)'/.freeze
+
+    # Public convenience API.
+    def self.build(document)
+      new(document).build
+    end
+
+    def initialize(document)
+      @document = document
+    end
+
+    def build
+      mapping = {}
+      @document.css("script").each do |script|
+        body = script.content
+        # Cheap pre-filter avoids regex scanning unrelated scripts.
+        next unless body.include?("_setImagesSrc")
+
+        body.scan(BLOCK_REGEX) do
+          match = Regexp.last_match
+          # Decode JS escapes so the resulting data URI matches browser output.
+          data_uri = unescape_js(match[:data])
+          # One data URI can map to multiple image ids.
+          match[:ids].scan(ID_REGEX) { |(id)| mapping[id] = data_uri }
+        end
+      end
+      mapping
+    end
+
+    private
+
+    # Google's inline JS escapes the trailing `=` of base64 padding as `\x3d`
+    # (and slashes as `\/`). We undo the minimal set of escapes that show up
+    # in practice — enough to make the resulting data URI byte-identical to
+    # what a browser would render after _setImagesSrc runs.
+    def unescape_js(str)
+      str.gsub(/\\x([0-9a-fA-F]{2})/) { [$1.to_i(16)].pack("C") }
+         .gsub('\\/', "/")
+         .gsub("\\\\", "\\")
+    end
+  end
+end

--- a/spec/carousel_spec.rb
+++ b/spec/carousel_spec.rb
@@ -1,0 +1,49 @@
+require "nokogiri"
+
+RSpec.describe Extractor::Carousel do
+  def doc_for(html)
+    Nokogiri::HTML(html)
+  end
+
+  it "prefers the candidate group with stronger tile signals when sizes tie" do
+    doc = doc_for(<<~HTML)
+      <html><body>
+        <div id="weak">
+          <div><a href="/search?stick=w1">One</a></div>
+          <div><a href="/search?stick=w2">Two</a></div>
+          <div><a href="/search?stick=w3">Three</a></div>
+        </div>
+        <div id="strong">
+          <div><a href="/search?stick=s1"><img alt="S1"><span>2001</span></a></div>
+          <div><a href="/search?stick=s2"><img alt="S2"><span>2002</span></a></div>
+          <div><a href="/search?stick=s3"><img alt="S3"><span>2003</span></a></div>
+        </div>
+      </body></html>
+    HTML
+
+    tiles = described_class.tiles(doc)
+    expect(tiles.size).to eq(3)
+    expect(tiles.first.parent["id"]).to eq("strong")
+  end
+
+  it "is deterministic on exact ties by picking the first group in DOM order" do
+    doc = doc_for(<<~HTML)
+      <html><body>
+        <div id="first">
+          <div><a href="/search?stick=f1"><img alt="F1"></a></div>
+          <div><a href="/search?stick=f2"><img alt="F2"></a></div>
+          <div><a href="/search?stick=f3"><img alt="F3"></a></div>
+        </div>
+        <div id="second">
+          <div><a href="/search?stick=s1"><img alt="S1"></a></div>
+          <div><a href="/search?stick=s2"><img alt="S2"></a></div>
+          <div><a href="/search?stick=s3"><img alt="S3"></a></div>
+        </div>
+      </body></html>
+    HTML
+
+    tiles = described_class.tiles(doc)
+    expect(tiles.size).to eq(3)
+    expect(tiles.first.parent["id"]).to eq("first")
+  end
+end

--- a/spec/cross_page_spec.rb
+++ b/spec/cross_page_spec.rb
@@ -1,0 +1,65 @@
+# Structural-invariant tests on two non-Van-Gogh carousel pages. These
+# fixtures intentionally differ from the Van Gogh layout (different CSS
+# class names, deeper anchor nesting, aria-label as the name source,
+# missing-extension rows). The point is to prove the extractor doesn't
+# silently regress against layout drift.
+
+RSpec.describe "Extractor against non-Van-Gogh carousel pages" do
+  describe "Frida Kahlo paintings (renamed classes, multi-id ii arrays)" do
+    let(:result) { Extractor.call(File.expand_path("fixtures/frida-kahlo-paintings.html", __dir__)) }
+
+    it "finds all five tiles" do
+      expect(result.size).to eq(5)
+    end
+
+    it "extracts canonical painting names" do
+      expect(result.map { |r| r["name"] }).to eq([
+        "The Two Fridas",
+        "Self-Portrait with Thorn Necklace and Hummingbird",
+        "The Broken Column",
+        "Henry Ford Hospital",
+        "My Birth",
+      ])
+    end
+
+    it "extracts the year as a single-element extensions array" do
+      expect(result.map { |r| r["extensions"] }).to eq([["1939"], ["1940"], ["1944"], ["1932"], ["1932"]])
+    end
+
+    it "absolutizes every link to https://www.google.com" do
+      expect(result.map { |r| r["link"] }).to all(start_with("https://www.google.com/search?"))
+    end
+
+    it "resolves inline thumbnails via the JS index, including multi-id blocks" do
+      images = result.map { |r| r["image"] }
+      expect(images[0]).to eq("data:image/jpeg;base64,FRIDA_BLOB_1")
+      # Both tiles 2 and 3 are listed in the same `ii` array and should
+      # resolve to the same blob — with the \x3d padding decoded.
+      expect(images[1]).to eq("data:image/jpeg;base64,FRIDA_BLOB_2==")
+      expect(images[2]).to eq("data:image/jpeg;base64,FRIDA_BLOB_2==")
+      # Tiles 4 and 5 are lazy-loaded on a real SERP → no inline blob.
+      expect(images[3]).to be_nil
+      expect(images[4]).to be_nil
+    end
+  end
+
+  describe "Nolan films (aria-label name, deeper nesting, missing ext)" do
+    let(:result) { Extractor.call(File.expand_path("fixtures/nolan-films.html", __dir__)) }
+
+    it "finds all five tiles" do
+      expect(result.size).to eq(5)
+    end
+
+    it "extracts canonical film names" do
+      expect(result.map { |r| r["name"] }).to eq([
+        "Oppenheimer", "Inception", "Interstellar", "The Dark Knight", "Dunkirk"
+      ])
+    end
+
+    it "captures year chips when present and nil when not (no crash on missing ext)" do
+      ext = result.map { |r| r["extensions"] }
+      expect(ext[0..3]).to eq([["2023"], ["2010"], ["2014"], ["2008"]])
+      expect(ext[4]).to be_nil
+    end
+  end
+end

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -1,0 +1,47 @@
+require "json"
+
+RSpec.describe Extractor do
+  describe ".call with the Van Gogh fixture" do
+    let(:expected) do
+      JSON.parse(File.read(File.join(FIXTURES_DIR, "expected-array.json")))["artworks"]
+    end
+    let(:result) { Extractor.call(File.join(FIXTURES_DIR, "van-gogh-paintings.html")) }
+
+    it "returns the same number of items as the SerpApi reference output" do
+      expect(result.size).to eq(expected.size)
+    end
+
+    it "matches name, extensions and link byte-for-byte across all items" do
+      mismatches = result.each_with_index.reject do |item, i|
+        %w[name extensions link].all? { |f| item[f] == expected[i][f] }
+      end
+      expect(mismatches).to be_empty, -> {
+        mismatches.first(3).map { |it, i|
+          "row #{i}: got=#{it.reject { |k,_| k == 'image' }.inspect} " \
+            "exp=#{expected[i].reject { |k,_| k == 'image' }.inspect}"
+        }.join("\n")
+      }
+    end
+
+    it "extracts every inline thumbnail present in the HTML exactly" do
+      # The page only ships the first N base64 thumbnails inline. The rest
+      # are URL thumbnails in in-file attributes (e.g. data-src). Those are
+      # still part of the page snapshot and should be surfaced as-is.
+      inline_expected = expected.each_with_index.select { |e, _| e["image"].to_s.start_with?("data:") }
+
+      inline_expected.each do |e, i|
+        expect(result[i]["image"]).to eq(e["image"]),
+          "mismatch on row #{i} (#{e['name']})"
+      end
+    end
+
+    it "matches image output byte-for-byte against expected array" do
+      mismatches = result.each_with_index.reject { |item, i| item["image"] == expected[i]["image"] }
+      expect(mismatches).to be_empty, -> {
+        mismatches.first(3).map { |(item, i)|
+          "row #{i}: got=#{item['image'].inspect} exp=#{expected[i]['image'].inspect}"
+        }.join("\n")
+      }
+    end
+  end
+end

--- a/spec/fixtures/frida-kahlo-paintings.html
+++ b/spec/fixtures/frida-kahlo-paintings.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html><head><title>frida kahlo paintings - Google Search</title></head>
+<body>
+<!-- Structural twin of the Van Gogh page with intentionally different
+     class names (`tile`, `lbl`, `ext`) and a different image-id prefix.
+     Validates that the extractor doesn't depend on Google's volatile
+     class names or any specific id format. -->
+<div id="kp-wholepage">
+  <g-scrolling-carousel>
+    <div class="container">
+      <div class="tile" style="position:absolute">
+        <a href="/search?q=The+Two+Fridas&amp;stick=ABCD1">
+          <img alt="The Two Fridas" id="thumb_fk_1" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-deferred="1">
+          <div class="lbl">
+            <div class="title">The Two Fridas</div>
+            <div class="ext">1939</div>
+          </div>
+        </a>
+      </div>
+      <div class="tile" style="position:absolute">
+        <a href="/search?q=Self-Portrait+with+Thorn+Necklace&amp;stick=ABCD2">
+          <img alt="Self-Portrait with Thorn Necklace and Hummingbird" id="thumb_fk_2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-deferred="1">
+          <div class="lbl">
+            <div class="title">Self-Portrait with Thorn Necklace and Hummingbird</div>
+            <div class="ext">1940</div>
+          </div>
+        </a>
+      </div>
+      <div class="tile" style="position:absolute">
+        <a href="/search?q=The+Broken+Column&amp;stick=ABCD3">
+          <img alt="The Broken Column" id="thumb_fk_3" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-deferred="1">
+          <div class="lbl">
+            <div class="title">The Broken Column</div>
+            <div class="ext">1944</div>
+          </div>
+        </a>
+      </div>
+      <div class="tile" style="position:absolute">
+        <a href="/search?q=Henry+Ford+Hospital&amp;stick=ABCD4">
+          <img alt="Henry Ford Hospital" id="thumb_fk_4" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-deferred="1">
+          <div class="lbl">
+            <div class="title">Henry Ford Hospital</div>
+            <div class="ext">1932</div>
+          </div>
+        </a>
+      </div>
+      <div class="tile" style="position:absolute">
+        <a href="/search?q=My+Birth&amp;stick=ABCD5">
+          <img alt="My Birth" id="thumb_fk_5" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-deferred="1">
+          <div class="lbl">
+            <div class="title">My Birth</div>
+            <div class="ext">1932</div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </g-scrolling-carousel>
+</div>
+
+<!-- Three inline image blobs (only some tiles get inline thumbnails on a
+     real SERP — the rest are lazy-loaded). Two of these use a multi-id
+     `ii` array to confirm that path works. -->
+<script>(function(){var s='data:image/jpeg;base64,FRIDA_BLOB_1';var ii=['thumb_fk_1'];var r='';_setImagesSrc(ii,s,r);})();</script>
+<script>(function(){var s='data:image/jpeg;base64,FRIDA_BLOB_2\x3d\x3d';var ii=['thumb_fk_2','thumb_fk_3'];var r='';_setImagesSrc(ii,s,r);})();</script>
+</body></html>

--- a/spec/fixtures/nolan-films.html
+++ b/spec/fixtures/nolan-films.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html><head><title>christopher nolan movies - Google Search</title></head>
+<body>
+<!-- Movie carousel variant. Different from the paintings layout in three
+     ways that have been seen in the wild:
+       1. The anchor carries `aria-label` instead of a child <div> title.
+       2. Tiles use deeper nesting around the anchor (extra wrapper div).
+       3. One tile has no extension chip at all (the parser must tolerate
+          missing extensions rather than crash).
+-->
+<div id="rcnt">
+  <div class="appbar"></div>
+  <g-scrolling-carousel>
+    <div>
+      <div class="card"><div class="inner">
+        <a aria-label="Oppenheimer" href="/search?q=Oppenheimer&amp;stick=N1">
+          <img alt="Oppenheimer" id="mv_1" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==">
+          <span class="year">2023</span>
+        </a>
+      </div></div>
+      <div class="card"><div class="inner">
+        <a aria-label="Inception" href="/search?q=Inception&amp;stick=N2">
+          <img alt="Inception" id="mv_2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==">
+          <span class="year">2010</span>
+        </a>
+      </div></div>
+      <div class="card"><div class="inner">
+        <a aria-label="Interstellar" href="/search?q=Interstellar&amp;stick=N3">
+          <img alt="Interstellar" id="mv_3" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==">
+          <span class="year">2014</span>
+        </a>
+      </div></div>
+      <div class="card"><div class="inner">
+        <a aria-label="The Dark Knight" href="/search?q=The+Dark+Knight&amp;stick=N4">
+          <img alt="The Dark Knight" id="mv_4" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==">
+          <span class="year">2008</span>
+        </a>
+      </div></div>
+      <div class="card"><div class="inner">
+        <a aria-label="Dunkirk" href="/search?q=Dunkirk&amp;stick=N5">
+          <img alt="Dunkirk" id="mv_5" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==">
+          <!-- intentionally no year chip -->
+        </a>
+      </div></div>
+    </div>
+  </g-scrolling-carousel>
+</div>
+
+<script>(function(){var s='data:image/jpeg;base64,NOLAN_1';var ii=['mv_1'];var r='';_setImagesSrc(ii,s,r);})();</script>
+<script>(function(){var s='data:image/jpeg;base64,NOLAN_2';var ii=['mv_2'];var r='';_setImagesSrc(ii,s,r);})();</script>
+</body></html>

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -1,0 +1,95 @@
+require "nokogiri"
+
+RSpec.describe Extractor::Item do
+  def tile_from(html)
+    Nokogiri::HTML.fragment(html).at_css("div")
+  end
+
+  it "extracts name from img alt and absolutizes the link" do
+    node = tile_from(<<~HTML)
+      <div>
+        <a href="/search?q=Foo&stick=abc">
+          <img alt="Foo" id="img1">
+          <div><div>1889</div></div>
+        </a>
+      </div>
+    HTML
+    out = described_class.parse(node, thumbnails: { "img1" => "data:image/jpeg;base64,AA" })
+    expect(out["name"]).to eq("Foo")
+    expect(out["link"]).to eq("https://www.google.com/search?q=Foo&stick=abc")
+    expect(out["extensions"]).to eq(["1889"])
+    expect(out["image"]).to eq("data:image/jpeg;base64,AA")
+  end
+
+  it "drops the placeholder 1x1 GIF in favor of the index" do
+    placeholder = "data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+    node = tile_from(<<~HTML)
+      <div>
+        <a href="/search?stick=1">
+          <img alt="Bar" id="img2" src="#{placeholder}">
+        </a>
+      </div>
+    HTML
+    out = described_class.parse(node, thumbnails: { "img2" => "data:image/jpeg;base64,REAL" })
+    expect(out["image"]).to eq("data:image/jpeg;base64,REAL")
+  end
+
+  it "skips container text so extensions aren't polluted by name+ext concatenation" do
+    node = tile_from(<<~HTML)
+      <div>
+        <a href="/search?stick=2">
+          <img alt="Starry" id="i">
+          <div class="wrapper">
+            <div>Starry</div>
+            <div>1889</div>
+          </div>
+        </a>
+      </div>
+    HTML
+    out = described_class.parse(node, thumbnails: {})
+    expect(out["extensions"]).to eq(["1889"])
+  end
+
+  it "returns nil when there is no anchor (malformed tile)" do
+    node = tile_from("<div><span>just text</span></div>")
+    expect(described_class.parse(node, thumbnails: {})).to be_nil
+  end
+
+  it "falls back to aria-label when img alt is missing" do
+    node = tile_from(<<~HTML)
+      <div>
+        <a aria-label="Fallback Name" href="/search?stick=3">
+          <img id="x">
+          <div><div>1901</div></div>
+        </a>
+      </div>
+    HTML
+    out = described_class.parse(node, thumbnails: {})
+    expect(out["name"]).to eq("Fallback Name")
+    expect(out["extensions"]).to eq(["1901"])
+  end
+
+  it "returns in-file thumbnail URL from data-src when present" do
+    node = tile_from(<<~HTML)
+      <div>
+        <a href="/search?stick=4">
+          <img alt="Remote" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-src="https://example.com/remote.jpg">
+        </a>
+      </div>
+    HTML
+    out = described_class.parse(node, thumbnails: {})
+    expect(out["image"]).to eq("https://example.com/remote.jpg")
+  end
+
+  it "returns in-file thumbnail URL from src when it is already non-placeholder http(s)" do
+    node = tile_from(<<~HTML)
+      <div>
+        <a href="/search?stick=5">
+          <img alt="RemoteSrc" src="https://example.com/src.jpg">
+        </a>
+      </div>
+    HTML
+    out = described_class.parse(node, thumbnails: {})
+    expect(out["image"]).to eq("https://example.com/src.jpg")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "extractor"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+  config.order = :random
+  Kernel.srand config.seed
+end
+
+FIXTURES_DIR = File.expand_path("../files", __dir__)

--- a/spec/thumbnail_index_spec.rb
+++ b/spec/thumbnail_index_spec.rb
@@ -1,0 +1,32 @@
+require "nokogiri"
+
+RSpec.describe Extractor::ThumbnailIndex do
+  def doc_for(script_body)
+    Nokogiri::HTML("<html><body><script>#{script_body}</script></body></html>")
+  end
+
+  it "maps a single id to its data URI" do
+    body = "(function(){var s='data:image/jpeg;base64,ABC';" \
+           "var ii=['img_1'];var r='';_setImagesSrc(ii,s,r);})();"
+    expect(described_class.build(doc_for(body))).to eq("img_1" => "data:image/jpeg;base64,ABC")
+  end
+
+  it "maps multiple ids in the same call to the same URI" do
+    body = "(function(){var s='data:image/jpeg;base64,XYZ';" \
+           "var ii=['a','b','c'];var r='';_setImagesSrc(ii,s,r);})();"
+    out = described_class.build(doc_for(body))
+    expect(out).to eq("a" => "data:image/jpeg;base64,XYZ",
+                      "b" => "data:image/jpeg;base64,XYZ",
+                      "c" => "data:image/jpeg;base64,XYZ")
+  end
+
+  it "decodes the \\x3d base64 padding escape Google emits" do
+    body = "(function(){var s='data:image/jpeg;base64,QUJDRA\\x3d\\x3d';" \
+           "var ii=['x'];var r='';_setImagesSrc(ii,s,r);})();"
+    expect(described_class.build(doc_for(body))["x"]).to eq("data:image/jpeg;base64,QUJDRA==")
+  end
+
+  it "ignores scripts that don't contain _setImagesSrc" do
+    expect(described_class.build(doc_for("var unrelated = 1;"))).to eq({})
+  end
+end


### PR DESCRIPTION
- Parse the bundled SERP HTML into a SerpApi-shaped array of  `{name, extensions, link, image}` without making HTTP requests.
- Detect carousel tiles by structural signal (`/search?...&stick=...` siblinggroups), not volatile Google CSS classes, so the parser works across Van Gogh and variant fixtures.
- Resolve thumbnails by parsing `_setImagesSrc(ii, s, r)` blocks into an `id -> image` map,including unescaping `\x3d` and `\/` values emitted in inline JS.
- Extract `extensions` from leaf text nodes under each anchor to avoid container-text noise (for example, concatenated `name+year`).
- Resolve `image` from values already present in the page file: inline JS mapping, inline non-placeholder data URIs, and in-file `data-src`/ `src` URLs.
- Add comprehensive RSpec coverage for golden output, cross-layout fixtures, item parsing, thumbnail indexing, and carousel selection behavior.

Run instructions are available in [RUN.md](https://github.com/kennankole/code-challenge/blob/d28ce93e702a01800d3ea783528ebd2cd86430d9/RUN.md).